### PR TITLE
fix a bug that assume the calling order

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1326,7 +1326,19 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
     /* Log DML if the audit role is valid or session logging is enabled */
     if ((auditOid != InvalidOid || auditLogBitmap != 0) &&
         !IsAbortedTransactionBlockState())
+    {
+        int iFlagPrivate=0;
+        if(auditEventStack==NULL)
+        {
+            iFlagPrivate=1;
+            auditEventStack=stack_push();
+        }
         log_select_dml(auditOid, rangeTabls);
+        if(iFlagPrivate==1)
+        {
+            stack_pop(auditEventStack->stackId);
+        }
+    }
 
     /* Call the next hook function */
     if (next_ExecutorCheckPerms_hook &&


### PR DESCRIPTION
We cannot assume that the hook function pgaudit_ExecutorCheckPerms_hook is executed after other hook functions.
Other extensions may be executed in a different order. 
This bug can be found from the tag 1.0.0 to the tag 1.5.2 and since the implementation code is changed from tag 1.6.0,we have to make another patch for it!